### PR TITLE
Hide controls after a period of inactivity

### DIFF
--- a/src/actions/preferences.ts
+++ b/src/actions/preferences.ts
@@ -3,6 +3,7 @@ import { i18nInstance } from '../translations';
 
 export const CHANGE_LANGUAGE = 'aiana/CHANGE_LANGUAGE';
 export const CHANGE_THEME = 'aiana/CHANGE_THEME';
+export const TOGGLE_ACTIVITY = 'aiana/TOGGLE_ACTIVITY';
 
 export function changeCurrentLanguage(language: string): AnyAction {
   i18nInstance.changeLanguage(language);
@@ -17,5 +18,12 @@ export function changeCurrentTheme(themeName: string): AnyAction {
   return {
     currentTheme: themeName,
     type: CHANGE_THEME
+  };
+}
+
+export function toggleActivity(isActive: boolean): AnyAction {
+  return {
+    isActive,
+    type: TOGGLE_ACTIVITY
   };
 }

--- a/src/components/app/ConnectedAiana.tsx
+++ b/src/components/app/ConnectedAiana.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import 'focus-visible';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -5,8 +6,10 @@ import {
   handleFullscreenChange,
   playerElementMounted
 } from '../../actions/player';
+import { toggleActivity } from '../../actions/preferences';
 import { handleFetchInitialData } from '../../actions/shared';
 import SvgFilters from '../../components/shared/filters';
+import { INACTIVITY_EVENTS, INACTIVITY_TIMER_DURATION } from '../../constants';
 import { IAianaState } from '../../reducers/index';
 import themes from '../../themes';
 import {
@@ -21,44 +24,42 @@ import PreferencesPanel from '../preferences/PreferencesPanel';
 import StyledAiana from '../styled/StyledAiana';
 import IntlWrapper from './IntlWrapper';
 
-interface IProps {
+interface IStateProps {
   availableThemes: string[];
   currentTheme: string;
+  isActive: boolean;
 }
 
 interface IDispatchProps {
   handleFetchInitialData(): void;
   handleFullscreenChange(isFullscreen: boolean): void;
   playerElementMounted(playerElement: HTMLElement): void;
+  toggleActivity(isActive: boolean): any;
 }
 
-interface IAiana extends IProps, IDispatchProps {}
+interface IAiana extends IStateProps, IDispatchProps {}
 
 class Aiana extends React.Component<IAiana> {
   private fullscreenRef = React.createRef<HTMLElement>();
+  private inactivityTimer?: number;
 
   constructor(props: any) {
     super(props);
     injectGlobalStyles();
   }
 
-  public componentDidMount() {
-    this.props.handleFetchInitialData();
-    this.props.playerElementMounted(this.fullscreenRef.current!);
-    addFullscreenChangeEventListener(this.fullscreenHandler);
-  }
-
-  public componentWillUnmount() {
-    removeFullscreenChangeEventListener(this.fullscreenHandler);
-  }
-
   public render() {
     const currentTheme = themes[this.props.currentTheme];
+
+    const elementClasses = classNames({
+      'aip-app': true,
+      inactive: !this.props.isActive
+    });
 
     return (
       <IntlWrapper>
         <ThemeProvider theme={currentTheme}>
-          <StyledAiana className="aip-app" innerRef={this.fullscreenRef}>
+          <StyledAiana className={elementClasses} innerRef={this.fullscreenRef}>
             <SvgFilters />
             <Player />
             <PreferencesPanel />
@@ -68,6 +69,52 @@ class Aiana extends React.Component<IAiana> {
     );
   }
 
+  public componentDidMount() {
+    this.props.handleFetchInitialData();
+    this.props.playerElementMounted(this.fullscreenRef.current!);
+    addFullscreenChangeEventListener(this.fullscreenHandler);
+
+    INACTIVITY_EVENTS.forEach((evt) => {
+      this.fullscreenRef.current!.addEventListener(
+        evt,
+        this.resetInactivityTimer,
+        true
+      );
+    });
+
+    this.inactivityTimer = window.setTimeout(
+      this.triggerInactivity,
+      INACTIVITY_TIMER_DURATION
+    );
+  }
+
+  public componentWillUnmount() {
+    removeFullscreenChangeEventListener(this.fullscreenHandler);
+
+    INACTIVITY_EVENTS.forEach((evt) => {
+      this.fullscreenRef.current!.removeEventListener(
+        evt,
+        this.resetInactivityTimer,
+        true
+      );
+    });
+  }
+
+  private triggerInactivity = () => {
+    this.props.toggleActivity(false);
+  };
+
+  private resetInactivityTimer = () => {
+    window.clearTimeout(this.inactivityTimer);
+
+    this.inactivityTimer = window.setTimeout(
+      this.triggerInactivity,
+      INACTIVITY_TIMER_DURATION
+    );
+
+    this.props.toggleActivity(true);
+  };
+
   private fullscreenHandler = () => {
     this.props.handleFullscreenChange(isDocumentFullscreen());
   };
@@ -75,13 +122,15 @@ class Aiana extends React.Component<IAiana> {
 
 const mapStateToProps = (state: IAianaState) => ({
   availableThemes: state.preferences.themes,
-  currentTheme: state.preferences.currentTheme
+  currentTheme: state.preferences.currentTheme,
+  isActive: state.preferences.isActive
 });
 
 const mapDispatchToProps = {
   handleFetchInitialData,
   handleFullscreenChange,
-  playerElementMounted
+  playerElementMounted,
+  toggleActivity
 };
 
 export default connect(

--- a/src/components/styled/StyledAiana.ts
+++ b/src/components/styled/StyledAiana.ts
@@ -10,6 +10,13 @@ const StyledAiana = styled.div`
   font-size: 1em;
   font-family: system, sans-serif;
 
+  &.inactive {
+    &,
+    & * {
+      cursor: none;
+    }
+  }
+
   -webkit-font-smoothing: antialiased;
 
   *,

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1,4 +1,7 @@
+import classNames from 'classnames';
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { IAianaState } from '../../reducers';
 import { hexToHsla } from '../../utils/colors';
 import styled from '../../utils/styled-components';
 import BookmarksBar from './bookmarks/BookmarksBar';
@@ -15,6 +18,10 @@ const StyledTimelineBar = styled.div`
 
   background-color: ${(props) => hexToHsla(props.theme.bg, 0.9)};
 
+  &.inactive {
+    opacity: 0;
+  }
+
   > div {
     width: 100%;
     height: 100%;
@@ -22,14 +29,31 @@ const StyledTimelineBar = styled.div`
   }
 `;
 
-const TimelineBar = () => (
-  <StyledTimelineBar className="aip-content-timeline">
-    <div>
-      <ChaptersBar />
-      <BookmarksBar />
-      <SlidesBar />
-    </div>
-  </StyledTimelineBar>
-);
+interface IStateProps {
+  isActive: boolean;
+}
 
-export default TimelineBar;
+function TimelineBar(props: IStateProps) {
+  return (
+    <StyledTimelineBar
+      className={classNames({
+        'aip-content-timeline': true,
+        inactive: !props.isActive
+      })}
+    >
+      <div>
+        <ChaptersBar />
+        <BookmarksBar />
+        <SlidesBar />
+      </div>
+    </StyledTimelineBar>
+  );
+}
+
+function mapStateToProps(state: IAianaState) {
+  return {
+    isActive: state.preferences.isActive
+  };
+}
+
+export default connect(mapStateToProps)(TimelineBar);

--- a/src/components/video/VideoPlayerControls.tsx
+++ b/src/components/video/VideoPlayerControls.tsx
@@ -1,4 +1,7 @@
+import classNames from 'classnames';
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { IAianaState } from '../../reducers';
 import { hexToHsla } from '../../utils/colors';
 import styled from '../../utils/styled-components';
 import AddBookmarkButton from '../buttons/add-bookmark/AddBookmarkButton';
@@ -13,8 +16,12 @@ const StyledControlsWrapper = styled.div`
   bottom: 0;
   width: 100%;
   /* 0.5 + 0.3125 */
-  padding: 0.8125em 1em 0.5em;
+  padding: 0.8125rem 1rem 0.5rem;
   background-color: ${(props) => hexToHsla(props.theme.bg, 0.9)};
+
+  &.inactive {
+    opacity: 0;
+  }
 `;
 
 const StyledControls = styled.div`
@@ -24,9 +31,15 @@ const StyledControls = styled.div`
   margin-top: 0.3125em;
 `;
 
-function VideoPlayerControls() {
+interface IStateProps {
+  isActive: boolean;
+}
+
+function VideoPlayerControls(props: IStateProps) {
   return (
-    <StyledControlsWrapper>
+    <StyledControlsWrapper
+      className={classNames({ inactive: !props.isActive })}
+    >
       <SeekBarSlider />
       <StyledControls className="aip-controls">
         <div className="aip-controls-left">
@@ -43,4 +56,10 @@ function VideoPlayerControls() {
   );
 }
 
-export default VideoPlayerControls;
+function mapStateToProps(state: IAianaState) {
+  return {
+    isActive: state.preferences.isActive
+  };
+}
+
+export default connect(mapStateToProps)(VideoPlayerControls);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,19 @@ export const DEFAULT_VOLUME = VOLUME_MAXIMUM;
 export const DEFAULT_VOLUME_STEP = 0.1;
 export const DEFAULT_VOLUME_STEP_MULTIPLIER = 2;
 
+export const INACTIVITY_TIMER_DURATION = 3000;
+export const INACTIVITY_EVENTS = [
+  'click',
+  'contextmenu',
+  'mousedown',
+  'mouseenter',
+  'mousemove',
+  'mouseup',
+  'keydown',
+  'keypress',
+  'keyup'
+];
+
 export const AVAILABLE_PLAYBACK_RATES = [
   0.25,
   0.5,

--- a/src/reducers/preferences.ts
+++ b/src/reducers/preferences.ts
@@ -1,5 +1,9 @@
 import { Reducer } from 'redux';
-import { CHANGE_LANGUAGE, CHANGE_THEME } from '../actions/preferences';
+import {
+  CHANGE_LANGUAGE,
+  CHANGE_THEME,
+  TOGGLE_ACTIVITY
+} from '../actions/preferences';
 import { LOAD_CONFIGURATION } from '../actions/shared';
 import {
   AVAILABLE_PLAYBACK_RATES,
@@ -19,6 +23,7 @@ export interface IPreferencesState {
   currentLanguage: string;
   currentTheme: string;
   customTheme: IAianaTheme;
+  isActive: boolean;
   languages: string[];
   playbackRates: number[];
   /**
@@ -36,6 +41,7 @@ const initialState: IPreferencesState = {
   currentLanguage: DEFAULT_LANG,
   currentTheme: DEFAULT_THEME,
   customTheme: InriaTheme,
+  isActive: true,
   languages: DEFAULT_AVAILABLE_LANGUAGES,
   playbackRates: AVAILABLE_PLAYBACK_RATES,
   seekStep: DEFAULT_SEEK_STEP,
@@ -47,6 +53,11 @@ const initialState: IPreferencesState = {
 
 const preferences: Reducer = (state = initialState, action) => {
   switch (action.type) {
+    case TOGGLE_ACTIVITY:
+      return {
+        ...state,
+        isActive: action.isActive
+      };
     case CHANGE_LANGUAGE:
       return {
         ...state,


### PR DESCRIPTION
When user is not performing any interaction with the player, I think it
is safe to assume some controls can be visually hidden from the GUI.

This commit adds this feature by listening to a list of events on the
main element. After a default of 3000ms, the controls and the timeline
will hide themselves. Any event from the list will show them again.